### PR TITLE
Preserve whitespace in bash value

### DIFF
--- a/bash/__init__.py
+++ b/bash/__init__.py
@@ -55,6 +55,6 @@ class bash(object):
         return bool(self.value())
 
     def value(self):
-        if self.stdout:
-            return self.stdout.strip().decode(encoding='UTF-8')
+        if self.stdout is not None:
+            return self.stdout.decode(encoding='UTF-8').rstrip('\r\n')
         return ''

--- a/tests.py
+++ b/tests.py
@@ -53,6 +53,10 @@ class TestBash(unittest.TestCase):
         # Shouldn't find anything because we haven't piped it.
         self.assertEqual(str(b.bash('grep setup')), '')
 
+    def test_value_preserves_whitespace(self):
+        result = bash("printf '  hi  \n'").value()
+        self.assertEqual(result, '  hi  ')
+
     def test_timeout_works(self):
         if not bash_module.SUBPROCESS_HAS_TIMEOUT:
             raise unittest.SkipTest()


### PR DESCRIPTION
## Summary
- avoid stripping spaces from command output when reading value
- add regression test ensuring trailing spaces are preserved

## Testing
- `python -m unittest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a1d3e2f870832a87ca0f81af42daff